### PR TITLE
[BN-1571]: Update Docker image names to publish/use new Strata registries

### DIFF
--- a/.github/workflows/_sbt_build_and_test.yml
+++ b/.github/workflows/_sbt_build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     services:
       bitcoin01:
         # Docker Hub image
-        image: toplprotocol/bitcoin-zmq:v25-regtest
+        image: stratalab/bitcoin-zmq:v25-regtest
         #
         ports:
           - 18444:18444
@@ -37,7 +37,7 @@ jobs:
         options: --name bitcoin01
       bitcoin02:
         # Docker Hub image
-        image: toplprotocol/bitcoin-zmq:v25-regtest
+        image: stratalab/bitcoin-zmq:v25-regtest
         #
         ports:
           - 18446:18444
@@ -68,7 +68,7 @@ jobs:
           export BRIDGE=`docker network ls | head -3 | tail -1 | awk -e '{print $2}'`
           echo "BRIDGE=$BRIDGE" >> $GITHUB_ENV
           echo "BRIDGE NETWORK: $BRIDGE"
-          export BIFROST_01=`docker run --rm -d --network=$BRIDGE --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v ${{ github.workspace }}/node01:/bifrost-staking:rw docker.io/toplprotocol/bifrost-tooling:2.0.0-beta3-29-11442de4 --  --config  /bifrost-staking/config.yaml --regtest`
+          export BIFROST_01=`docker run --rm -d --network=$BRIDGE --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v ${{ github.workspace }}/node01:/bifrost-staking:rw docker.io/stratalab/strata-node-tooling:0.0.0-8200-7a9041ed --  --config  /bifrost-staking/config.yaml --regtest`
           echo "BIFROST_01=$BIFROST_01" >> $GITHUB_ENV
           echo "Bifrost01 container id: $BIFROST_01"
           curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > cs
@@ -124,7 +124,7 @@ jobs:
               echo "    stakes: [10000, 10000]" >> node02/config.yaml
               export IP_CONTAINER=`docker network inspect $BRIDGE | jq  ".[0].Containers.\"$BIFROST_01\".IPv4Address" | sed  's:"::g' | sed -n 's:\(.*\)/.*:\1:p'`
               echo "IP_CONTAINER: $IP_CONTAINER"
-              export BIFROST_02=`docker run --rm -d  --network=$BRIDGE --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/bifrost-staking:rw docker.io/toplprotocol/bifrost-tooling:2.0.0-beta3-29-11442de4 --  --config  /bifrost-staking/config.yaml --regtest`
+              export BIFROST_02=`docker run --rm -d  --network=$BRIDGE --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/bifrost-staking:rw docker.io/stratalab/strata-node-tooling:0.0.0-8200-7a9041ed --  --config  /bifrost-staking/config.yaml --regtest`
               sbt coverage integration/test coverageReport
               docker stop $BIFROST_01
               docker stop $BIFROST_02

--- a/.github/workflows/_sbt_build_and_test.yml
+++ b/.github/workflows/_sbt_build_and_test.yml
@@ -68,7 +68,7 @@ jobs:
           export BRIDGE=`docker network ls | head -3 | tail -1 | awk -e '{print $2}'`
           echo "BRIDGE=$BRIDGE" >> $GITHUB_ENV
           echo "BRIDGE NETWORK: $BRIDGE"
-          export BIFROST_01=`docker run --rm -d --network=$BRIDGE --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v ${{ github.workspace }}/node01:/bifrost-staking:rw docker.io/stratalab/strata-node-tooling:0.0.0-8200-7a9041ed --  --config  /bifrost-staking/config.yaml --regtest`
+          export BIFROST_01=`docker run --rm -d --network=$BRIDGE --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v ${{ github.workspace }}/node01:/staking:rw docker.io/stratalab/strata-node-tooling:0.0.0-8200-7a9041ed --  --config  /staking/config.yaml --regtest`
           echo "BIFROST_01=$BIFROST_01" >> $GITHUB_ENV
           echo "Bifrost01 container id: $BIFROST_01"
           curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > cs
@@ -124,7 +124,7 @@ jobs:
               echo "    stakes: [10000, 10000]" >> node02/config.yaml
               export IP_CONTAINER=`docker network inspect $BRIDGE | jq  ".[0].Containers.\"$BIFROST_01\".IPv4Address" | sed  's:"::g' | sed -n 's:\(.*\)/.*:\1:p'`
               echo "IP_CONTAINER: $IP_CONTAINER"
-              export BIFROST_02=`docker run --rm -d  --network=$BRIDGE --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/bifrost-staking:rw docker.io/stratalab/strata-node-tooling:0.0.0-8200-7a9041ed --  --config  /bifrost-staking/config.yaml --regtest`
+              export BIFROST_02=`docker run --rm -d  --network=$BRIDGE --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/staking:rw docker.io/stratalab/strata-node-tooling:0.0.0-8200-7a9041ed --  --config  /staking/config.yaml --regtest`
               sbt coverage integration/test coverageReport
               docker stop $BIFROST_01
               docker stop $BIFROST_02

--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v13
       - uses: olafurpg/setup-gpg@v3
-      - name: Deploy (release only)
-        run: sbt "buildClient; ci-release"
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      # - name: Deploy (release only)
+      #   run: sbt "buildClient; ci-release"
+      #   env:
+      #     PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+      #     PGP_SECRET: ${{ secrets.PGP_SECRET }}
+      #     SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      #     SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
       - name: Log in to the Github Container registry
         uses: docker/login-action@v1
         with:
@@ -44,25 +44,25 @@ jobs:
         env:
           DOCKER_PUBLISH: true
           RELEASE_PUBLISH: true
-  deploy-docs:
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: [ sbt-build-and-test ]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: npm
-          cache-dependency-path: microsite/package-lock.json
-      - name: Install dependencies
-        run: cd microsite && npm ci
-      - name: Build website
-        run: cd microsite &&  npm run build
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./microsite/build
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+  # deploy-docs:
+  #   name: Deploy to GitHub Pages
+  #   runs-on: ubuntu-latest
+  #   needs: [ sbt-build-and-test ]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 18
+  #         cache: npm
+  #         cache-dependency-path: microsite/package-lock.json
+  #     - name: Install dependencies
+  #       run: cd microsite && npm ci
+  #     - name: Build website
+  #       run: cd microsite &&  npm run build
+  #     - name: Deploy to GitHub Pages
+  #       uses: peaceiris/actions-gh-pages@v3
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         publish_dir: ./microsite/build
+  #         user_name: github-actions[bot]
+  #         user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/build.sbt
+++ b/build.sbt
@@ -53,12 +53,12 @@ lazy val commonDockerSettings = List(
   dockerAliases := dockerAliases.value.flatMap { alias =>
     if (sys.env.get("RELEASE_PUBLISH").getOrElse("false").toBoolean)
       Seq(
-        alias.withRegistryHost(Some("ghcr.io/topl")),
-        alias.withRegistryHost(Some("docker.io/toplprotocol"))
+        alias.withRegistryHost(Some("ghcr.io/stratalab")),
+        alias.withRegistryHost(Some("docker.io/stratalab"))
       )
     else
       Seq(
-        alias.withRegistryHost(Some("ghcr.io/topl"))
+        alias.withRegistryHost(Some("ghcr.io/stratalab"))
       )
   },
   dockerBaseImage := "adoptopenjdk/openjdk11:jdk-11.0.16.1_1-ubuntu",
@@ -69,12 +69,12 @@ lazy val commonDockerSettings = List(
 
 lazy val dockerPublishSettingsConsensus = List(
   dockerExposedPorts ++= Seq(4000),
-  Docker / packageName := "topl-btc-bridge-consensus"
+  Docker / packageName := "strata-btc-bridge-consensus"
 ) ++ commonDockerSettings
 
 lazy val dockerPublishSettingsPublicApi = List(
   dockerExposedPorts ++= Seq(5000),
-  Docker / packageName := "topl-btc-bridge-public-api"
+  Docker / packageName := "strata-btc-bridge-public-api"
 ) ++ commonDockerSettings
 
 def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
@@ -137,7 +137,7 @@ lazy val consensus = (project in file("consensus"))
       dockerPublishSettingsConsensus
     else mavenPublishSettings,
     commonSettings,
-    name := "topl-btc-bridge-consensus",
+    name := "strata-btc-bridge-consensus",
     libraryDependencies ++=
       Dependencies.toplBtcBridge.consensus ++
         Dependencies.toplBtcBridge.test
@@ -152,7 +152,7 @@ lazy val publicApi =
         dockerPublishSettingsPublicApi
       else mavenPublishSettings,
       commonSettings,
-      name := "topl-btc-bridge-public-api",
+      name := "strata-btc-bridge-public-api",
       libraryDependencies ++=
         Dependencies.toplBtcBridge.publicApi ++
           Dependencies.toplBtcBridge.test

--- a/consensus/src/main/scala/co/topl/bridge/consensus/core/ConsensusParamsDescriptor.scala
+++ b/consensus/src/main/scala/co/topl/bridge/consensus/core/ConsensusParamsDescriptor.scala
@@ -17,8 +17,8 @@ trait ConsensusParamsDescriptor {
     import builder._
 
     OParser.sequence(
-      programName("topl-btc-bridge-consensus"),
-      head("topl-btc-bridge-consensus", "0.1"),
+      programName("strata-btc-bridge-consensus"),
+      head("strata-btc-bridge-consensus", "0.1"),
       opt[Int]("checkpoint-interval")
         .action((x, c) => c.copy(checkpointInterval = x))
         .text(

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,4 +2,4 @@
 
 This docker file is used to create a BTC regtest node. It is very simple
 and just hardcodes the parameters exactly as what we need for our tests.
-It is published in docker hub as `toplprotocol/bitcoin-zmq:v25-regtest`.
+It is published in docker hub as `stratalab/bitcoin-zmq:v25-regtest`.

--- a/docker/bifrost/Dockerfile
+++ b/docker/bifrost/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/topl/bifrost-node:2.0.0-beta3-29-11442de4
+FROM ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed
 USER root
 RUN curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > cs
 RUN chmod +x cs

--- a/integration/prepareAndLauncIntegrationTest.sh
+++ b/integration/prepareAndLauncIntegrationTest.sh
@@ -15,14 +15,14 @@ openssl ec -in clientPrivateKey.pem -pubout -out clientPublicKey.pem
 
 # Start the containers
 echo "Starting containers"
-docker run --rm -d --add-host host.docker.internal:host-gateway -p 18444:18444 -p 18443:18443 -p 28332:28332 --name bitcoin01 toplprotocol/bitcoin-zmq:v25-regtest
-docker run --rm -d --add-host host.docker.internal:host-gateway -p 18446:18444 -p 18445:18443 -p 28333:28332 --name bitcoin02 toplprotocol/bitcoin-zmq:v25-regtest
+docker run --rm -d --add-host host.docker.internal:host-gateway -p 18444:18444 -p 18443:18443 -p 28332:28332 --name bitcoin01 stratalab/bitcoin-zmq:v25-regtest
+docker run --rm -d --add-host host.docker.internal:host-gateway -p 18446:18444 -p 18445:18443 -p 28333:28332 --name bitcoin02 stratalab/bitcoin-zmq:v25-regtest
 
 
 sudo rm -fr node01
 sudo rm -fr node02
 #rm -fr staking/*
-#docker run --rm -i --user root  -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/config:/bifrost -v (pwd)/staking:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 -- --cli true --config  /bifrost/config.conf < config.txt
+#docker run --rm -i --user root  -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/config:/bifrost -v (pwd)/staking:/bifrost-staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed -- --cli true --config  /bifrost/config.conf < config.txt
 #sudo chown -R mundacho staking/
 mkdir -p node01
 mkdir -p node02

--- a/integration/prepareAndLauncIntegrationTest.sh
+++ b/integration/prepareAndLauncIntegrationTest.sh
@@ -49,10 +49,10 @@ bifrost:
     stakes: [10000, 10000]
 "
 
-export CONTAINER_ID=`docker run --rm -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v $(pwd)/node01:/staking:rw toplprotocol/bifrost-tooling:v2.0.0-beta3 --  --config  /staking/config.yaml --regtest`
+export CONTAINER_ID=`docker run --rm -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v $(pwd)/node01:/staking:rw stratalab/strata-node-tooling:0.0.0-8200-7a9041ed --  --config  /staking/config.yaml --regtest`
 export IP_CONTAINER=`docker network inspect bridge | jq  ".[0].Containers.\"$CONTAINER_ID\".IPv4Address" | sed  's:"::g' | sed -n 's:\(.*\)/.*:\1:p'`
 echo "IP_CONTAINER: $IP_CONTAINER"
-docker run --rm -d --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/staking:rw toplprotocol/bifrost-tooling:v2.0.0-beta3 --  --config  /staking/config.yaml --regtest
+docker run --rm -d --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/staking:rw stratalab/strata-node-tooling:0.0.0-8200-7a9041ed --  --config  /staking/config.yaml --regtest
 
 echo "Waiting for bifrost to start"
 # Wait for bifrost to start

--- a/integration/prepareAndLauncIntegrationTest.sh
+++ b/integration/prepareAndLauncIntegrationTest.sh
@@ -22,7 +22,7 @@ docker run --rm -d --add-host host.docker.internal:host-gateway -p 18446:18444 -
 sudo rm -fr node01
 sudo rm -fr node02
 #rm -fr staking/*
-#docker run --rm -i --user root  -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/config:/bifrost -v (pwd)/staking:/bifrost-staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed -- --cli true --config  /bifrost/config.conf < config.txt
+#docker run --rm -i --user root  -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/config:/bifrost -v (pwd)/staking:/staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed -- --cli true --config  /bifrost/config.conf < config.txt
 #sudo chown -R mundacho staking/
 mkdir -p node01
 mkdir -p node02
@@ -49,10 +49,10 @@ bifrost:
     stakes: [10000, 10000]
 "
 
-export CONTAINER_ID=`docker run --rm -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v $(pwd)/node01:/bifrost-staking:rw toplprotocol/bifrost-tooling:v2.0.0-beta3 --  --config  /bifrost-staking/config.yaml --regtest`
+export CONTAINER_ID=`docker run --rm -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v $(pwd)/node01:/staking:rw toplprotocol/bifrost-tooling:v2.0.0-beta3 --  --config  /staking/config.yaml --regtest`
 export IP_CONTAINER=`docker network inspect bridge | jq  ".[0].Containers.\"$CONTAINER_ID\".IPv4Address" | sed  's:"::g' | sed -n 's:\(.*\)/.*:\1:p'`
 echo "IP_CONTAINER: $IP_CONTAINER"
-docker run --rm -d --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/bifrost-staking:rw toplprotocol/bifrost-tooling:v2.0.0-beta3 --  --config  /bifrost-staking/config.yaml --regtest
+docker run --rm -d --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/staking:rw toplprotocol/bifrost-tooling:v2.0.0-beta3 --  --config  /staking/config.yaml --regtest
 
 echo "Waiting for bifrost to start"
 # Wait for bifrost to start

--- a/integration/setupBifrost.sh
+++ b/integration/setupBifrost.sh
@@ -3,7 +3,7 @@
 sudo rm -fr node01
 sudo rm -fr node02
 #rm -fr staking/*
-#docker run --rm -i --user root  -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/config:/bifrost -v (pwd)/staking:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 -- --cli true --config  /bifrost/config.conf < config.txt
+#docker run --rm -i --user root  -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/config:/bifrost -v (pwd)/staking:/bifrost-staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed -- --cli true --config  /bifrost/config.conf < config.txt
 #sudo chown -R mundacho staking/
 mkdir -p node01
 mkdir -p node02
@@ -35,7 +35,7 @@ bifrost:
 #cp -R staking/genesis/* node02/
 #cp -R staking/stakers/(ls staking/stakers/ | head -1) node01/stakers
 #cp -R staking/stakers/(ls staking/stakers/ | tail -1) node02/stakers
-set CONTAINER_ID (docker run --rm -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/node01:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config  /bifrost-staking/config.yaml --regtest)
+set CONTAINER_ID (docker run --rm -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/node01:/bifrost-staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed --  --config  /bifrost-staking/config.yaml --regtest)
 set IP_CONTAINER (docker network inspect bridge | jq  ".[0].Containers.\"$CONTAINER_ID\".IPv4Address" | sed  's:"::g' | sed -n 's:\(.*\)/.*:\1:p')
 echo "IP_CONTAINER: $IP_CONTAINER"
-docker run --rm -d --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v (pwd)/node02:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config  /bifrost-staking/config.yaml --regtest
+docker run --rm -d --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v (pwd)/node02:/bifrost-staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed --  --config  /bifrost-staking/config.yaml --regtest

--- a/integration/setupBifrost.sh
+++ b/integration/setupBifrost.sh
@@ -3,7 +3,7 @@
 sudo rm -fr node01
 sudo rm -fr node02
 #rm -fr staking/*
-#docker run --rm -i --user root  -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/config:/bifrost -v (pwd)/staking:/bifrost-staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed -- --cli true --config  /bifrost/config.conf < config.txt
+#docker run --rm -i --user root  -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/config:/bifrost -v (pwd)/staking:/staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed -- --cli true --config  /bifrost/config.conf < config.txt
 #sudo chown -R mundacho staking/
 mkdir -p node01
 mkdir -p node02
@@ -35,7 +35,7 @@ bifrost:
 #cp -R staking/genesis/* node02/
 #cp -R staking/stakers/(ls staking/stakers/ | head -1) node01/stakers
 #cp -R staking/stakers/(ls staking/stakers/ | tail -1) node02/stakers
-set CONTAINER_ID (docker run --rm -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/node01:/bifrost-staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed --  --config  /bifrost-staking/config.yaml --regtest)
+set CONTAINER_ID (docker run --rm -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v (pwd)/node01:/staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed --  --config  /staking/config.yaml --regtest)
 set IP_CONTAINER (docker network inspect bridge | jq  ".[0].Containers.\"$CONTAINER_ID\".IPv4Address" | sed  's:"::g' | sed -n 's:\(.*\)/.*:\1:p')
 echo "IP_CONTAINER: $IP_CONTAINER"
-docker run --rm -d --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v (pwd)/node02:/bifrost-staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed --  --config  /bifrost-staking/config.yaml --regtest
+docker run --rm -d --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v (pwd)/node02:/staking:rw ghcr.io/stratalab/strata-node:0.0.0-8200-7a9041ed --  --config  /staking/config.yaml --regtest

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -391,7 +391,7 @@ package object bridge extends ProcessOps {
   }
 
   val CS_CMD = Option(System.getenv("CI"))
-    .map(_ => s"${Option(System.getenv("GITHUB_WORKSPACE"))}/cs")
+    .map(_ => s"${Option(System.getenv("""GITHUB_WORKSPACE"""))}/cs")
     .getOrElse("cs")
 
   val csParams = Seq(

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -391,7 +391,7 @@ package object bridge extends ProcessOps {
   }
 
   val CS_CMD = Option(System.getenv("CI"))
-    .map(_ => "/home/runner/work/topl-btc-bridge/topl-btc-bridge/cs")
+    .map(_ => s"${Option(System.getenv("GITHUB_WORKSPACE"))}/cs")
     .getOrElse("cs")
 
   val csParams = Seq(

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -391,7 +391,7 @@ package object bridge extends ProcessOps {
   }
 
   val CS_CMD = Option(System.getenv("CI"))
-    .map(_ => s"${Option(System.getenv("""GITHUB_WORKSPACE"""))}/cs")
+    .map(_ => s"${System.getenv("""GITHUB_WORKSPACE""")}/cs")
     .getOrElse("cs")
 
   val csParams = Seq(

--- a/public-api/src/main/scala/co/topl/bridge/publicapi/PublicApiParamsDescriptor.scala
+++ b/public-api/src/main/scala/co/topl/bridge/publicapi/PublicApiParamsDescriptor.scala
@@ -11,8 +11,8 @@ trait PublicApiParamsDescriptor {
     import builder._
 
     OParser.sequence(
-      programName("topl-btc-bridge-public-api"),
-      head("topl-btc-bridge-public-api", "0.1"),
+      programName("strata-btc-bridge-public-api"),
+      head("strata-btc-bridge-public-api", "0.1"),
       opt[File]("config-file")
         .action((x, c) => c.copy(configurationFile = x))
         .validate(x =>
@@ -20,7 +20,7 @@ trait PublicApiParamsDescriptor {
           else failure("Configuration file does not exist")
         )
         .text(
-          "Configuration file for the topl-btc-bridge-public-api service"
+          "Configuration file for the strata-btc-bridge-public-api service"
         )
     )
   }


### PR DESCRIPTION
## Purpose
Update Docker images for repo and update references to other published images.

## Approach
* Update Docker images to publish to new `stratalab` registries
* Update consumed Docker images to pull from new `stratalab` registries.
* Comment out Maven publish step
* Comment out Docusaurus publish step
* Update `CS_CMD` to get value from GitHub env var `GITHUB_WORKSPACE` (which maps to the cloned folder).

### Summary of  Docker Image Updates

Consumed images:
* `toplprotocol/bitcoin-zmq` -> `stratalab/bitcoin-zmq`
* `toplprotocol/bifrost-tooling:2.0.0-beta3-29-11442de4` -> `stratalab/strata-node-tooling:0.0.0-8200-7a9041ed`

Published images:
`stratalab/strata-btc-bridge-consensus` https://hub.docker.com/repository/docker/stratalab/strata-btc-bridge-consensus/general
`ghcr.io/stratalab/strata-btc-bridge-consensus` https://github.com/StrataLab/strata-btc-bridge/pkgs/container/strata-btc-bridge-consensus

`stratalab/strata-btc-bridge-public-api` https://hub.docker.com/repository/docker/stratalab/strata-btc-bridge-public-api/general
`ghcr.io/stratalab/strata-btc-bridge-public-api` https://github.com/StrataLab/strata-btc-bridge/pkgs/container/strata-btc-bridge-public-api

## Testing
* https://github.com/StrataLab/strata-btc-bridge/actions/runs/10855085819
* https://github.com/StrataLab/strata-btc-bridge/actions/runs/10855085700

## Tickets
*BN-1571
